### PR TITLE
Support official path param

### DIFF
--- a/src/components/compositions/data-retrieval.tsx
+++ b/src/components/compositions/data-retrieval.tsx
@@ -1,10 +1,15 @@
 import { Manifest } from "@/lib/manifest";
-import { PropsWithChildren, ReactNode, createContext, useEffect, useState } from "react";
-
+import {
+  PropsWithChildren,
+  ReactNode,
+  createContext,
+  useEffect,
+  useState,
+} from "react";
 
 interface DataContextType {
-    data: Manifest | null;
-    fetchData: () => Promise<Manifest>;
+  data: Manifest | null;
+  fetchData: () => Promise<Manifest>;
 }
 
 export const DataContext = createContext<DataContextType>({
@@ -13,11 +18,12 @@ export const DataContext = createContext<DataContextType>({
 });
 
 export function DataService({ children }: PropsWithChildren): ReactNode {
-
   const [data, setData] = useState<Manifest | null>(null);
 
   const handleFetchData: () => Promise<Manifest> = async () => {
-    const dt = await fetch("https://wb5lsudgvpt4f4j4pxomg5z3ui0dcgjt.lambda-url.ap-southeast-2.on.aws/").then((res) => res.json());
+    const dt = await fetch("https://micropython.org/pi/v2/index.json").then(
+      (res) => res.json()
+    );
     setData(dt);
     return dt;
   };
@@ -25,15 +31,13 @@ export function DataService({ children }: PropsWithChildren): ReactNode {
   const dataContext: DataContextType = {
     data,
     fetchData: handleFetchData,
-  }
+  };
 
   useEffect(() => {
     handleFetchData();
   }, []);
 
   return (
-    <DataContext.Provider value={dataContext}>
-      {children}
-    </DataContext.Provider>
+    <DataContext.Provider value={dataContext}>{children}</DataContext.Provider>
   );
 }

--- a/src/components/compositions/data-retrieval.tsx
+++ b/src/components/compositions/data-retrieval.tsx
@@ -12,6 +12,11 @@ interface DataContextType {
   fetchData: () => Promise<Manifest>;
 }
 
+// TODO: replace once path added
+// const manifestUrl = "https://micropython.org/pi/v2/index.json";
+const manifestUrl =
+  "https://wb5lsudgvpt4f4j4pxomg5z3ui0dcgjt.lambda-url.ap-southeast-2.on.aws/";
+
 export const DataContext = createContext<DataContextType>({
   data: null,
   fetchData: async () => Promise.reject(),
@@ -21,9 +26,7 @@ export function DataService({ children }: PropsWithChildren): ReactNode {
   const [data, setData] = useState<Manifest | null>(null);
 
   const handleFetchData: () => Promise<Manifest> = async () => {
-    const dt = await fetch("https://micropython.org/pi/v2/index.json").then(
-      (res) => res.json()
-    );
+    const dt = await fetch(manifestUrl).then((res) => res.json());
     setData(dt);
     return dt;
   };

--- a/src/lib/manifest.ts
+++ b/src/lib/manifest.ts
@@ -6,7 +6,8 @@ export interface Package {
     versions: {
       [version: string]: string[];
     };
-    url: string;
+    path?: string;
+    url?: string;
     version: string;
   }
   

--- a/src/pages/detail/detail-page.tsx
+++ b/src/pages/detail/detail-page.tsx
@@ -4,109 +4,157 @@ import { CopyIcon } from "lucide-react";
 import { PropsWithChildren, useContext, useEffect, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import { useParams } from "react-router-dom";
-	
+
 import remarkGfm from "remark-gfm";
 
-
 export function PackageDetailPage() {
-    const dataContext = useContext(DataContext);
-    const { packageName } = useParams();
+  const dataContext = useContext(DataContext);
+  const { packageName } = useParams();
 
-    const item = dataContext.data?.packages.find((pkg) => pkg.name === packageName);
+  const item = dataContext.data?.packages.find(
+    (pkg) => pkg.name === packageName
+  );
 
-    const [markdown, setMarkdown] = useState<string | null>(null);
+  const [markdown, setMarkdown] = useState<string | null>(null);
 
-    useEffect(() => {
-        if (!item) {
-            return;
-        }
+  useEffect(() => {
+    if (!item) {
+      return;
+    }
 
-        const readme = item.url.replace("github.com", "raw.githubusercontent.com").replace('/blob', '').replace('/tree', '') + '/README.md';
-        fetch(readme)
-            .then((res) => {
-                if (res.status === 200) {
-                return res.text();
-                } else {
-                    return null;
-                }
-            })
-            .then(setMarkdown);
-    }, [item]);
+    let readme: string | null = null;
+    if (item.path) {
+      readme = `https://raw.githubusercontent.com/micropython/micropython-lib/master/${item.path}/README.md`;
+    } else if (item.url) {
+      readme =
+        item.url
+          .replace("github.com", "raw.githubusercontent.com")
+          .replace("/blob", "")
+          .replace("/tree", "") + "/README.md";
+    }
+    if (readme !== null) {
+      fetch(readme)
+        .then((res) => {
+          if (res.status === 200) {
+            return res.text();
+          } else {
+            return null;
+          }
+        })
+        .then(setMarkdown);
+    }
+  }, [item]);
 
-    return (
-        <div className="flex flex-col gap-y-8">
-            <div className="flex w-full items-start gap-x-8">
-                <aside className="sticky top-8 hidden max-w-96 shrink-0 lg:block">{item && <PackageInfo pkg={item} />}</aside>
-                <main className="flex-1"><div className="lg:hidden">{item && <PackageInfo pkg={item} />}</div><MarkdownComp markdown={markdown}/></main>
-            </div>
-        </div>
-    );
+  return (
+    <div className="flex flex-col gap-y-8">
+      <div className="flex w-full items-start gap-x-8">
+        <aside className="sticky top-8 hidden max-w-96 shrink-0 lg:block">
+          {item && <PackageInfo pkg={item} />}
+        </aside>
+        <main className="flex-1">
+          <div className="lg:hidden">{item && <PackageInfo pkg={item} />}</div>
+          <MarkdownComp markdown={markdown} />
+        </main>
+      </div>
+    </div>
+  );
 }
 
 function PackageInfo({ pkg }: { pkg: Package }) {
-    return (
-        <div className="flex flex-col w-full gap-y-4">
-        <div>
-                    <h1 className="text-3xl font-bold">{pkg.name}</h1>
-                    <p className="text-lg text-slate-500">{pkg.description}</p>
-                </div>
-            <div className="flex flex-col lg:flex-col gap-y-4 gap-x-8">
-                <div className="flex flex-col sm:flex-row lg:flex-col gap-y-4 gap-x-8">
-                    <PackageInfoData name="Install"><InstallCommand packageName={pkg.name} /></PackageInfoData>
-                    <PackageInfoData name="OTA Install"><InstallCommand packageName={pkg.name} ota={true} /></PackageInfoData>
-                </div>
-                <div className="flex flex-row lg:flex-col gap-y-4 gap-x-8">
-                    <PackageInfoData name="Version">{pkg.version}</PackageInfoData>
-                    <PackageInfoData name="Author">{pkg.author.length === 0 ? '-' : pkg.author}</PackageInfoData>
-                    <PackageInfoData name="License">{pkg.license}</PackageInfoData>
-                </div>
-            </div>
+  return (
+    <div className="flex flex-col w-full gap-y-4">
+      <div>
+        <h1 className="text-3xl font-bold">{pkg.name}</h1>
+        <p className="text-lg text-slate-500">{pkg.description}</p>
+      </div>
+      <div className="flex flex-col lg:flex-col gap-y-4 gap-x-8">
+        <div className="flex flex-col sm:flex-row lg:flex-col gap-y-4 gap-x-8">
+          <PackageInfoData name="Install">
+            <InstallCommand packageName={pkg.name} />
+          </PackageInfoData>
+          <PackageInfoData name="OTA Install">
+            <InstallCommand packageName={pkg.name} ota={true} />
+          </PackageInfoData>
         </div>
-    );
+        <div className="flex flex-row lg:flex-col gap-y-4 gap-x-8">
+          <PackageInfoData name="Version">{pkg.version}</PackageInfoData>
+          <PackageInfoData name="Author">
+            {pkg.author.length === 0 ? "-" : pkg.author}
+          </PackageInfoData>
+          <PackageInfoData name="License">{pkg.license}</PackageInfoData>
+        </div>
+      </div>
+    </div>
+  );
 }
 
-function PackageInfoData({ name, children }: PropsWithChildren<{ name: string }>) {
-    return (
-        <div className="flex flex-col gap-y-1">
-            <div className="text-sm text-slate-500">{name}</div>
-            <div>{children}</div>
-        </div>
-    );
+function PackageInfoData({
+  name,
+  children,
+}: PropsWithChildren<{ name: string }>) {
+  return (
+    <div className="flex flex-col gap-y-1">
+      <div className="text-sm text-slate-500">{name}</div>
+      <div>{children}</div>
+    </div>
+  );
 }
 
-
-function InstallCommand({ packageName, ota = false }: { packageName: string, ota?: boolean }) {
-    const command = ota ? `import mip; mip.install("${packageName}")` : `mpremote mip install ${packageName}`;
-    const handleCopy = () => {
-        navigator.clipboard.writeText(command);
-    };
-    return (
+function InstallCommand({
+  packageName,
+  ota = false,
+}: {
+  packageName: string;
+  ota?: boolean;
+}) {
+  const command = ota
+    ? `import mip; mip.install("${packageName}")`
+    : `mpremote mip install ${packageName}`;
+  const handleCopy = () => {
+    navigator.clipboard.writeText(command);
+  };
+  return (
+    <div>
+      <div className="bg-slate-200 rounded py-2 px-4 flex flex-row items-center gap-x-4 text-sm justify-between">
         <div>
-        <div className="bg-slate-200 rounded py-2 px-4 flex flex-row items-center gap-x-4 text-sm justify-between">
-            <div><code>{command}</code></div>
-            <div onClick={() => handleCopy} className="hover:text-slate-900 text-slate-500 cursor-pointer"><CopyIcon size={16} /></div>
+          <code>{command}</code>
         </div>
+        <div
+          onClick={() => handleCopy}
+          className="hover:text-slate-900 text-slate-500 cursor-pointer"
+        >
+          <CopyIcon size={16} />
         </div>
-    );
+      </div>
+    </div>
+  );
 }
 
 function MarkdownComp({ markdown }: { markdown: string | null }) {
-    return (
-        <ReactMarkdown
-            className='markdown w-full'
-            remarkPlugins={[remarkGfm]}
-            components={{
-                code({ className, children, ...props }) {
-                    return <code className={`${className} `} {...props}>
-                    {children}
-                </code>
-                },
-                pre({ children }) {
-                    return <div className="w-full"><div className="overflow-scroll flex-shrink-0"><pre>{children}</pre></div></div>;
-                }
-            }}
-        >
-            {markdown}
-        </ReactMarkdown>
-    );
+  return (
+    <ReactMarkdown
+      className="markdown w-full"
+      remarkPlugins={[remarkGfm]}
+      components={{
+        code({ className, children, ...props }) {
+          return (
+            <code className={`${className} `} {...props}>
+              {children}
+            </code>
+          );
+        },
+        pre({ children }) {
+          return (
+            <div className="w-full">
+              <div className="overflow-scroll flex-shrink-0">
+                <pre>{children}</pre>
+              </div>
+            </div>
+          );
+        },
+      }}
+    >
+      {markdown}
+    </ReactMarkdown>
+  );
 }

--- a/src/pages/home/home-page.tsx
+++ b/src/pages/home/home-page.tsx
@@ -1,126 +1,133 @@
+import { DataContext } from "@/components/compositions/data-retrieval";
 import { LoadingSpinner } from "@/components/ui/loading";
-import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from "@/components/ui/table";
+import {
+  Table,
+  TableHeader,
+  TableRow,
+  TableHead,
+  TableBody,
+  TableCell,
+} from "@/components/ui/table";
 import { H1, Lead } from "@/components/ui/typography";
-import { Manifest, Package } from "@/lib/manifest";
-import { useReactTable, getCoreRowModel, flexRender, ColumnDef } from "@tanstack/react-table";
-import { useState, useEffect } from "react";
+import { Package } from "@/lib/manifest";
+import {
+  useReactTable,
+  getCoreRowModel,
+  flexRender,
+  ColumnDef,
+} from "@tanstack/react-table";
+import { useContext } from "react";
 import { useNavigate } from "react-router-dom";
-  
-  const columns: ColumnDef<Package>[] = [
-    {
-      accessorKey: "name",
-      header: "Name",
-    },
-    {
-      accessorKey: "author",
-      header: "Author",
-      cell: ({ row }) => <div>{row.getValue("author") || "-"}</div>,
-    },
-    {
-      accessorKey: "license",
-      header: "License",
-    },
-    {
-      accessorKey: "description",
-      header: "Description",
-      cell: ({ row }) => <div>{row.getValue("description") || "-"}</div>,
-    },
-  ];
+
+const columns: ColumnDef<Package>[] = [
+  {
+    accessorKey: "name",
+    header: "Name",
+  },
+  {
+    accessorKey: "author",
+    header: "Author",
+    cell: ({ row }) => <div>{row.getValue("author") || "-"}</div>,
+  },
+  {
+    accessorKey: "license",
+    header: "License",
+  },
+  {
+    accessorKey: "description",
+    header: "Description",
+    cell: ({ row }) => <div>{row.getValue("description") || "-"}</div>,
+  },
+];
 
 export function HomePage() {
-    const [manifest, setManifest] = useState<Manifest | null>(null);
-    const navigate = useNavigate();
-  
-    // Retrieve mip package manifest from https://micropython.org/pi/v2/index.json
-    useEffect(() => {
-      fetch("https://micropython.org/pi/v2/index.json")
-        .then((res) => res.json())
-        .then(setManifest);
-    }, []);
-    const table = useReactTable({
-      data: manifest?.packages ?? [],
-      columns,
-      getCoreRowModel: getCoreRowModel(),
-    });
+  const dataContext = useContext(DataContext);
+  const navigate = useNavigate();
 
-    const handleNavigate = (pkg: Package) => {
-      navigate(`/packages/${pkg.name}`);
-    }
-  
-    return (
-      <div className="">
-        <H1>
-          <code>
-            <a
-              href="https://docs.micropython.org/en/latest/reference/packages.html"
-              className="underline text-blue-400"
-            >
-              mip
-            </a>
-          </code>{" "}
-          package list
-        </H1>
-        <Lead>
-          why write it when you can <code>mip</code> it?
-        </Lead>
-        <div className="w-full flex-grow">
-          {manifest === null ? (
-            <div className="m-auto">
-              <LoadingSpinner />
-            </div>
-          ) : (
-            <div className="rounded-md border">
-              <Table>
-                <TableHeader className="bg-slate-100">
-                  {table.getHeaderGroups().map((headerGroup) => (
-                    <TableRow key={headerGroup.id}>
-                      {headerGroup.headers.map((header) => (
-                        <TableHead key={header.id}>
-                          {header.isPlaceholder
-                            ? null
-                            : flexRender(
-                                header.column.columnDef.header,
-                                header.getContext()
-                              )}
-                        </TableHead>
+  const table = useReactTable({
+    data: dataContext.data?.packages ?? [],
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+  });
+
+  const handleNavigate = (pkg: Package) => {
+    navigate(`/packages/${pkg.name}`);
+  };
+
+  return (
+    <div className="">
+      <H1>
+        <code>
+          <a
+            href="https://docs.micropython.org/en/latest/reference/packages.html"
+            className="underline text-blue-400"
+          >
+            mip
+          </a>
+        </code>{" "}
+        package list
+      </H1>
+      <Lead>
+        why write it when you can <code>mip</code> it?
+      </Lead>
+      <div className="w-full flex-grow">
+        {dataContext.data === null ? (
+          <div className="m-auto">
+            <LoadingSpinner />
+          </div>
+        ) : (
+          <div className="rounded-md border">
+            <Table>
+              <TableHeader className="bg-slate-100">
+                {table.getHeaderGroups().map((headerGroup) => (
+                  <TableRow key={headerGroup.id}>
+                    {headerGroup.headers.map((header) => (
+                      <TableHead key={header.id}>
+                        {header.isPlaceholder
+                          ? null
+                          : flexRender(
+                              header.column.columnDef.header,
+                              header.getContext()
+                            )}
+                      </TableHead>
+                    ))}
+                  </TableRow>
+                ))}
+              </TableHeader>
+              <TableBody>
+                {table.getRowModel().rows?.length ? (
+                  table.getRowModel().rows.map((row) => (
+                    <TableRow
+                      key={row.id}
+                      data-state={row.getIsSelected() && "selected"}
+                      onClick={() => handleNavigate(row.original as Package)}
+                      className="cursor-pointer"
+                    >
+                      {row.getVisibleCells().map((cell) => (
+                        <TableCell key={cell.id}>
+                          {flexRender(
+                            cell.column.columnDef.cell,
+                            cell.getContext()
+                          )}
+                        </TableCell>
                       ))}
                     </TableRow>
-                  ))}
-                </TableHeader>
-                <TableBody>
-                  {table.getRowModel().rows?.length ? (
-                    table.getRowModel().rows.map((row) => (
-                      <TableRow
-                        key={row.id}
-                        data-state={row.getIsSelected() && "selected"}
-                        onClick={() => handleNavigate(row.original as Package)}
-                        className="cursor-pointer"
-                      >
-                        {row.getVisibleCells().map((cell) => (
-                          <TableCell key={cell.id}>
-                            {flexRender(
-                              cell.column.columnDef.cell,
-                              cell.getContext()
-                            )}
-                          </TableCell>
-                        ))}
-                      </TableRow>
-                    ))
-                  ) : (
-                    <TableRow>
-                      <TableCell
-                        colSpan={columns.length}
-                        className="h-24 text-center"
-                      >
-                        No results.
-                      </TableCell>
-                    </TableRow>
-                  )}
-                </TableBody>
-              </Table>
-            </div>
-          )}
-        </div>
+                  ))
+                ) : (
+                  <TableRow>
+                    <TableCell
+                      colSpan={columns.length}
+                      className="h-24 text-center"
+                    >
+                      No results.
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        )}
       </div>
-    );
-  }
+    </div>
+  );
+}


### PR DESCRIPTION
Migrates from custom, injected `url` param, to official `path` param introduced in https://github.com/micropython/micropython-lib/pull/910 . This removes dependency on Proof of Concept injection code and non-scalable lambda, as well as receiving increased correctness found in the proper solution.

Should not be merged until https://github.com/micropython/micropython-lib/pull/910 is.